### PR TITLE
Arrays of fb

### DIFF
--- a/absyntax_utils/search_base_type.cc
+++ b/absyntax_utils/search_base_type.cc
@@ -123,9 +123,11 @@ void *search_base_type_c::handle_datatype_identifier(token_c *type_name) {
   if (iter2 != function_block_type_symtable.end())
     return iter2->second->accept(*this); // iter2->second is the type_decl 
   
-  /* Type declaration not found!! */
-  ERROR;
-    
+  /* Type declaration not found in type symbol tables.
+   * This could be a standard library function block (like TON, CTU, etc.)
+   * which are stored in library_element_symtable (not accessible from here).
+   * Return NULL and let the caller handle it appropriately.
+   */
   return NULL;
 }
 

--- a/lib/C/iec_types_all.h
+++ b/lib/C/iec_types_all.h
@@ -117,6 +117,12 @@ typedef struct {\
 } type;\
 __DECLARE_COMPLEX_STRUCT(type)
 
+#define __DECLARE_ARRAY_TYPE_WRAPPER(type, base, size)\
+typedef struct {\
+  __IEC_##base##_t table size;\
+} type;\
+__DECLARE_COMPLEX_STRUCT(type)
+
 #define __DECLARE_STRUCT_TYPE(type, elements)\
 typedef struct {\
   elements\

--- a/stage1_2/iec_bison.yy
+++ b/stage1_2/iec_bison.yy
@@ -2579,7 +2579,7 @@ single_element_type_name:
  * Since the standard does not allow them,
  * we leave it commented out for the time being...
  */
-//| prev_declared_derived_function_block_name
+| prev_declared_derived_function_block_name
 | prev_declared_subrange_type_name
 | prev_declared_enumerated_type_name
 ;

--- a/stage1_2/iec_bison.yy
+++ b/stage1_2/iec_bison.yy
@@ -7955,24 +7955,24 @@ return_statement:
 
 
 fb_invocation:
-  prev_declared_fb_name '(' ')'
+  symbolic_variable '(' ')'
 	{$$ = new fb_invocation_c($1, NULL, NULL, locloc(@$));	}
-| prev_declared_fb_name '(' param_assignment_formal_list ')'
+| symbolic_variable '(' param_assignment_formal_list ')'
 	{$$ = new fb_invocation_c($1, $3, NULL, locloc(@$));}
-| prev_declared_fb_name '(' param_assignment_nonformal_list ')'
+| symbolic_variable '(' param_assignment_nonformal_list ')'
 	{$$ = new fb_invocation_c($1, NULL, $3, locloc(@$));}
 /* ERROR_CHECK_BEGIN */
-| prev_declared_fb_name ')'
-	{$$ = NULL; print_err_msg(locl(@1), locf(@2), "'(' missing after function block name in ST statement."); yynerrs++;}
-| prev_declared_fb_name param_assignment_formal_list ')'
-	{$$ = NULL; print_err_msg(locl(@1), locf(@2), "'(' missing after function block name in ST statement."); yynerrs++;}
-| prev_declared_fb_name '(' error ')'
+| symbolic_variable ')'
+	{$$ = NULL; print_err_msg(locl(@1), locf(@2), "'(' missing after function block variable in ST statement."); yynerrs++;}
+| symbolic_variable param_assignment_formal_list ')'
+	{$$ = NULL; print_err_msg(locl(@1), locf(@2), "'(' missing after function block variable in ST statement."); yynerrs++;}
+| symbolic_variable '(' error ')'
 	{$$ = NULL; print_err_msg(locf(@3), locl(@3), "invalid parameter list in function block invocation in ST statement."); yyerrok;}
-| prev_declared_fb_name '(' error
+| symbolic_variable '(' error
 	{$$ = NULL; print_err_msg(locl(@2), locf(@3), "')' missing after parameter list of function block invocation in ST statement."); yyerrok;}
-| prev_declared_fb_name '(' param_assignment_formal_list error
+| symbolic_variable '(' param_assignment_formal_list error
 	{$$ = NULL; print_err_msg(locl(@3), locf(@4), "')' missing after parameter list of function block invocation in ST statement."); yyerrok;}
-| prev_declared_fb_name '(' param_assignment_nonformal_list error
+| symbolic_variable '(' param_assignment_nonformal_list error
 	{$$ = NULL; print_err_msg(locl(@3), locf(@4), "')' missing after parameter list of function block invocation in ST statement."); yyerrok;}
 /* ERROR_CHECK_END */
 ;

--- a/stage3/fill_candidate_datatypes.cc
+++ b/stage3/fill_candidate_datatypes.cc
@@ -2284,7 +2284,15 @@ void *fill_candidate_datatypes_c::visit(assignment_statement_c *symbol) {
 /* B 3.2.2 Subprogram Control Statements */
 /*****************************************/
 void *fill_candidate_datatypes_c::visit(fb_invocation_c *symbol) {
-	symbol_c *fb_decl = search_var_instance_decl->get_basetype_decl(symbol->fb_name);
+	/* First, type the fb_name (which may now be a complex symbolic_variable like array_variable_c) */
+	/* Note: We only populate candidate_datatypes here; datatype is set in narrow_candidate_datatypes_c */
+	if (symbol->fb_name != NULL) {
+		symbol->fb_name->accept(*this);
+	}
+	
+	/* For array elements like my_array[1], we need to use search_varfb_instance_type_c to get the element type */
+	search_varfb_instance_type_c search_varfb_instance_type(current_scope);
+	symbol_c *fb_decl = search_varfb_instance_type.get_basetype_decl(symbol->fb_name);
 	if (! get_datatype_info_c::is_function_block(fb_decl )) fb_decl = NULL;
 	if (NULL == fb_decl) ERROR; /* Although a call to a non-declared FB is a semantic error, this is currently caught by stage 2! */
 	

--- a/stage3/narrow_candidate_datatypes.cc
+++ b/stage3/narrow_candidate_datatypes.cc
@@ -758,6 +758,12 @@ void *narrow_candidate_datatypes_c::visit(ref_type_decl_c *symbol) {return narro
 /*********************/
 // SYM_REF1(symbolic_variable_c, var_name)
 void *narrow_candidate_datatypes_c::visit(symbolic_variable_c *symbol) {
+	// If datatype is NULL but we have exactly one candidate, set it to that candidate
+	// This matches the behavior of other visitors (see lines 443, 455) for literal constants
+	if (symbol->datatype == NULL && symbol->candidate_datatypes.size() == 1) {
+		symbol->datatype = symbol->candidate_datatypes[0];
+	}
+	
 	symbol->var_name->datatype = symbol->datatype;
 	return NULL;
 }

--- a/stage3/narrow_candidate_datatypes.cc
+++ b/stage3/narrow_candidate_datatypes.cc
@@ -1694,6 +1694,11 @@ void *narrow_candidate_datatypes_c::visit(assignment_statement_c *symbol) {
 /*****************************************/
 
 void *narrow_candidate_datatypes_c::visit(fb_invocation_c *symbol) {
+	/* Visit fb_name to set datatypes on any sub-expressions (e.g., array subscripts) */
+	if (symbol->fb_name != NULL) {
+		symbol->fb_name->accept(*this);
+	}
+	
 	/* Note: We do not use the symbol->called_fb_declaration value (set in fill_candidate_datatypes_c)
 	 *       because we try to identify any other datatype errors in the expressions used in the 
 	 *       parameters to the FB call (e.g.  fb_var(var1 * 56 + func(var * 43)) )

--- a/stage4/generate_c/generate_c.cc
+++ b/stage4/generate_c/generate_c.cc
@@ -478,6 +478,14 @@ class analyse_variable_c: public search_visitor_c {
         symbol = singleton_->first_non_fb_identifier;
       }
       
+      // If symbol is NULL after reassignment (e.g., when accessing a FB instance directly
+      // without a field selector, as happens with VAR_IN_OUT parameters during FB invocation),
+      // use the original symbol passed to this function instead.
+      if (NULL == symbol) {
+        // Restore the original symbol - it's a FB instance, so we need to look it up in the scope
+        symbol = first_non_fb;
+      }
+      
       search_var_instance_decl_c search_var_instance_decl(scope);
       
       return search_var_instance_decl.get_vartype(symbol);

--- a/stage4/generate_c/generate_c.hh
+++ b/stage4/generate_c/generate_c.hh
@@ -50,6 +50,7 @@
 
 
 #include <string>
+#include <vector>
 #include "../../absyntax/absyntax.hh"
 #include "../../absyntax/visitor.hh"
 

--- a/stage4/generate_c/generate_c_st.cc
+++ b/stage4/generate_c/generate_c_st.cc
@@ -234,6 +234,21 @@ void *print_getter(symbol_c *symbol) {
   }
   
   // Default case: use standard macro generation
+  // For bare FB instances (e.g., when accessing VAR_IN_OUT parameters during FB invocation),
+  // we need to check if the symbol is a FB and handle it specially
+  if (get_datatype_info_c::is_function_block(symbol->datatype)) {
+    // This is a bare FB instance - just print it directly without macro wrappers
+    // The caller (print_check_function) will append the field name
+    print_variable_prefix();
+    wanted_variablegeneration = complextype_base_vg;
+    symbol->accept(*this);
+    s4o.print(",");
+    wanted_variablegeneration = complextype_suffix_vg;
+    symbol->accept(*this);
+    wanted_variablegeneration = expression_vg;
+    return NULL;
+  }
+  
   unsigned int vartype = analyse_variable_c::first_nonfb_vardecltype(symbol, scope_);
   if (wanted_variablegeneration == fparam_output_vg) {
     if (vartype == search_var_instance_decl_c::external_vt) {

--- a/stage4/generate_c/generate_c_st.cc
+++ b/stage4/generate_c/generate_c_st.cc
@@ -123,6 +123,20 @@ class generate_c_st_c: public generate_c_base_and_typeid_c {
       this->set_variable_prefix(saved_prefix);
     }
     
+    // Helper method to check if an array has elementary type elements
+    // Returns true for arrays of INT, BOOL, TIME, etc. (which use wrapper elements)
+    // Returns false for arrays of FBs (which use raw FB struct elements)
+    bool is_elementary_array(array_variable_c *array_var) {
+      if (array_var == NULL) return false;
+      
+      symbol_c *array_type = search_varfb_instance_type->get_basetype_decl(array_var->subscripted_variable);
+      if (array_type == NULL) return false;
+      
+      symbol_c *element_type = get_datatype_info_c::get_array_storedtype_id(array_type);
+      if (element_type == NULL) return false;
+      
+      return get_datatype_info_c::is_ANY_ELEMENTARY(element_type);
+    }
     
 
 
@@ -179,6 +193,44 @@ void *print_getter(symbol_c *symbol) {
         return NULL;
       }
     }
+  }
+  
+  // Special case: Elementary array element access (e.g., INT_ARR[1])
+  // For forced variables to work correctly on array elements, we need to pass the element wrapper
+  // to the macro so it checks the element's .flags, not the array's .flags.
+  // Generate: __GET_VAR(data__->INT_ARR.value.table[idx],)
+  array_variable_c *array_var = dynamic_cast<array_variable_c *>(symbol);
+  if (array_var != NULL && is_elementary_array(array_var)) {
+    unsigned int vartype = analyse_variable_c::first_nonfb_vardecltype(symbol, scope_);
+    
+    if (wanted_variablegeneration == fparam_output_vg) {
+      if (vartype == search_var_instance_decl_c::external_vt)
+        s4o.print(GET_EXTERNAL_BY_REF);
+      else if (vartype == search_var_instance_decl_c::located_vt)
+        s4o.print(GET_LOCATED_BY_REF);
+      else
+        s4o.print(GET_VAR_BY_REF);
+    }
+    else {
+      if (vartype == search_var_instance_decl_c::external_vt)
+        s4o.print(GET_EXTERNAL);
+      else if (vartype == search_var_instance_decl_c::located_vt)
+        s4o.print(GET_LOCATED);
+      else
+        s4o.print(GET_VAR);
+    }
+    
+    s4o.print("(");
+    print_variable_prefix();
+    // Print the array element wrapper path: data__->ARR.value.table[idx]
+    accept_without_prefix(array_var->subscripted_variable);
+    symbol_c *array_type = search_varfb_instance_type->get_basetype_decl(array_var->subscripted_variable);
+    s4o.print(".value.table");
+    current_array_type = array_type;
+    array_var->subscript_list->accept(*this);
+    current_array_type = NULL;
+    s4o.print(",)");
+    return NULL;
   }
   
   // Default case: use standard macro generation
@@ -276,6 +328,42 @@ void *print_setter(symbol_c* symbol,
           return NULL;
         }
       }
+    }
+    
+    // Special case: Elementary array element access (e.g., INT_ARR[1] := value)
+    // For forced variables to work correctly on array elements, we need to pass the element wrapper
+    // to the macro so it checks the element's .flags, not the array's .flags.
+    // Generate: __SET_VAR(, data__->INT_ARR.value.table[idx], , value)
+    array_variable_c *array_var = dynamic_cast<array_variable_c *>(symbol);
+    if (array_var != NULL && is_elementary_array(array_var)) {
+      unsigned int vartype = analyse_variable_c::first_nonfb_vardecltype(symbol, scope_);
+      
+      if (vartype == search_var_instance_decl_c::external_vt)
+        s4o.print(SET_EXTERNAL);
+      else if (vartype == search_var_instance_decl_c::located_vt)
+        s4o.print(SET_LOCATED);
+      else
+        s4o.print(SET_VAR);
+      
+      s4o.print("(");
+      // Use empty prefix approach: __SET_VAR(, element_wrapper, , value)
+      // This makes the macro check element.flags and set element.value
+      s4o.print(",");
+      print_variable_prefix();
+      // Print the array element wrapper path: data__->ARR.value.table[idx]
+      accept_without_prefix(array_var->subscripted_variable);
+      symbol_c *array_type = search_varfb_instance_type->get_basetype_decl(array_var->subscripted_variable);
+      s4o.print(".value.table");
+      current_array_type = array_type;
+      array_var->subscript_list->accept(*this);
+      current_array_type = NULL;
+      s4o.print(",,");
+      // Print the value
+      wanted_variablegeneration = expression_vg;
+      print_check_function(type, value, fb_value);
+      s4o.print(")");
+      wanted_variablegeneration = expression_vg;
+      return NULL;
     }
   }
   
@@ -535,6 +623,11 @@ void *visit(array_variable_c *symbol) {
 
         s4o.print(".value.table");
         symbol->subscript_list->accept(*this);
+        
+        // For elementary array elements, append .value to access the raw value from the wrapper
+        if (is_elementary_array(symbol)) {
+          s4o.print(".value");
+        }
 
         current_array_type = NULL;
       }

--- a/stage4/generate_c/generate_c_st.cc
+++ b/stage4/generate_c/generate_c_st.cc
@@ -335,8 +335,14 @@ void *visit(structured_variable_c *symbol) {
        * 
        *        For the above reason, a STEP must be handled as a FB, i.e. it does NOT contain the 'flags' and 'value' elements!
        */
-      if (   get_datatype_info_c::is_function_block(symbol->record_variable->datatype)
-          || get_datatype_info_c::is_sfc_step      (symbol->record_variable->datatype)) {
+      /* SPECIAL CASE: If record_variable is an array_variable_c (e.g., my_array[1].PT), 
+       * we must NOT print the field here in the base phase. The array suffix (.table[...]) 
+       * must be printed first, then the field (.PT) in the suffix phase.
+       * Otherwise we get incorrect code like: MY_ARRAY.PT.table[0] instead of MY_ARRAY.table[0].PT
+       */
+      if (   (get_datatype_info_c::is_function_block(symbol->record_variable->datatype)
+           || get_datatype_info_c::is_sfc_step      (symbol->record_variable->datatype))
+          && (dynamic_cast<array_variable_c *>(symbol->record_variable) == NULL)) {
         if (NULL == symbol->record_variable->scope) ERROR;
         search_var_instance_decl_c search_var_instance_decl(symbol->record_variable->scope);
         if      (search_var_instance_decl_c::external_vt == search_var_instance_decl.get_vartype(get_var_name_c::get_last_field(symbol->record_variable)))
@@ -351,8 +357,11 @@ void *visit(structured_variable_c *symbol) {
     case complextype_suffix_vg:
       symbol->record_variable->accept(*this);
       // the following condition MUST be a negation of the above condition used in the 'case complextype_base_vg:'
+      // SPECIAL CASE: If record_variable is an array_variable_c, we need to print the field here
+      // in the suffix phase (after .table[...]), not in the base phase.
       if (!(   get_datatype_info_c::is_function_block(symbol->record_variable->datatype)     // if the record variable is not a FB... 
-            || get_datatype_info_c::is_sfc_step      (symbol->record_variable->datatype))) { // ...nor an SFC step name, then it will certainly be a structure!
+            || get_datatype_info_c::is_sfc_step      (symbol->record_variable->datatype))    // ...nor an SFC step name, then it will certainly be a structure!
+          || (dynamic_cast<array_variable_c *>(symbol->record_variable) != NULL)) {          // OR if it's an array element access (e.g., my_array[1].PT)
         if (dynamic_cast<deref_operator_c *>(symbol->record_variable) != NULL)
           s4o.print("->"); /* please read the comment in visit(deref_operator_c *) tio understand what this line is doing! */
         else

--- a/stage4/generate_c/generate_c_st.cc
+++ b/stage4/generate_c/generate_c_st.cc
@@ -425,7 +425,7 @@ void *visit(array_variable_c *symbol) {
         current_array_type = search_varfb_instance_type->get_basetype_decl(symbol->subscripted_variable);
         if (current_array_type == NULL) ERROR;
 
-        s4o.print(".table");
+        s4o.print(".value.table");
         symbol->subscript_list->accept(*this);
 
         current_array_type = NULL;

--- a/stage4/generate_c/generate_c_st.cc
+++ b/stage4/generate_c/generate_c_st.cc
@@ -237,15 +237,14 @@ void *print_getter(symbol_c *symbol) {
   // For bare FB instances (e.g., when accessing VAR_IN_OUT parameters during FB invocation),
   // we need to check if the symbol is a FB and handle it specially
   if (get_datatype_info_c::is_function_block(symbol->datatype)) {
-    // This is a bare FB instance - just print it directly without macro wrappers
-    // The caller (print_check_function) will append the field name
-    print_variable_prefix();
+    // This is a bare FB instance - just print the variable name without prefix or commas
+    // The caller (print_check_function) already handles the prefix and GET_VAR macro
+    variablegeneration_t old_wanted_variablegeneration = wanted_variablegeneration;
     wanted_variablegeneration = complextype_base_vg;
     symbol->accept(*this);
-    s4o.print(",");
     wanted_variablegeneration = complextype_suffix_vg;
     symbol->accept(*this);
-    wanted_variablegeneration = expression_vg;
+    wanted_variablegeneration = old_wanted_variablegeneration;
     return NULL;
   }
   

--- a/stage4/generate_c/generate_c_st.cc
+++ b/stage4/generate_c/generate_c_st.cc
@@ -206,12 +206,17 @@ void *print_setter(symbol_c* symbol,
         print_variable_prefix();
         // It is my (MJS) conviction that by this time the following will always be true...
         //   wanted_variablegeneration == expression_vg;
+        // For complex FB expressions (like array elements), we need to print them directly
+        // without going through print_getter, so we temporarily set variable_prefix to NULL
+        const char *saved_prefix = this->get_variable_prefix();
+        this->set_variable_prefix(NULL);
         fb_symbol->accept(*this);
+        this->set_variable_prefix(saved_prefix);
         s4o.print(".,");
         symbol->accept(*this);
     }
     s4o.print(",");
-    s4o.print(",");    
+    s4o.print(",");
   } else {
     print_variable_prefix();
     s4o.print(",");    
@@ -1018,7 +1023,7 @@ void *visit(fb_invocation_c *symbol) {
     if (param_type == NULL) ERROR;
     
     /* now output the value assignment */
-    if (param_value != NULL)
+    if (param_value != NULL) {
       if ((param_direction == function_param_iterator_c::direction_in) ||
           (param_direction == function_param_iterator_c::direction_inout)) {
         if (this->is_variable_prefix_null()) {
@@ -1033,16 +1038,23 @@ void *visit(fb_invocation_c *symbol) {
         }
         s4o.print(";\n" + s4o.indent_spaces);
       }
+    }
   } /* for(...) */
 
   /* now call the function... */
   function_block_type_name->accept(*this);
   s4o.print(FB_FUNCTION_SUFFIX);
   s4o.print("(");
-  if (search_var_instance_decl->get_vartype(symbol->fb_name) != search_var_instance_decl_c::external_vt)
+  search_var_instance_decl_c::vt_t vt = search_var_instance_decl->get_vartype(symbol->fb_name);
+  if (vt != search_var_instance_decl_c::external_vt)
     s4o.print("&");
   print_variable_prefix();
+  // For complex FB expressions (like array elements), we need to print them directly
+  // without going through print_getter, so we temporarily set variable_prefix to NULL
+  const char *saved_prefix = this->get_variable_prefix();
+  this->set_variable_prefix(NULL);
   symbol->fb_name->accept(*this);
+  this->set_variable_prefix(saved_prefix);
   s4o.print(")");
 
   /* loop through each function parameter, find the variable to which

--- a/stage4/generate_c/generate_c_st.cc
+++ b/stage4/generate_c/generate_c_st.cc
@@ -113,6 +113,15 @@ class generate_c_st_c: public generate_c_base_and_typeid_c {
     }
 
   private:
+    // Helper method to accept a symbol without variable prefix
+    // This is used when we need to print variable names directly without
+    // going through the getter/setter macros (e.g., for array subscripts in FB arrays)
+    void accept_without_prefix(symbol_c *symbol) {
+      const char *saved_prefix = this->get_variable_prefix();
+      this->set_variable_prefix(NULL);
+      symbol->accept(*this);
+      this->set_variable_prefix(saved_prefix);
+    }
     
     
 
@@ -158,11 +167,7 @@ void *print_getter(symbol_c *symbol) {
         print_variable_prefix();
         // Print the array access with .value.table[idx].FIELD (without trailing dot)
         // The __GET_VAR macro will add .value to access the raw value
-        // Temporarily disable variable_prefix to avoid nested __GET_VAR calls
-        const char *saved_prefix = this->get_variable_prefix();
-        this->set_variable_prefix(NULL);
-        array_var->subscripted_variable->accept(*this);
-        this->set_variable_prefix(saved_prefix);
+        accept_without_prefix(array_var->subscripted_variable);
         s4o.print(".value.table");
         current_array_type = array_type;
         array_var->subscript_list->accept(*this);
@@ -254,11 +259,7 @@ void *print_setter(symbol_c* symbol,
           s4o.print("(");
           print_variable_prefix();
           // Print the array access with .value.table[idx]. (with trailing dot)
-          // Temporarily disable variable_prefix to avoid nested __SET_VAR calls
-          const char *saved_prefix = this->get_variable_prefix();
-          this->set_variable_prefix(NULL);
-          array_var->subscripted_variable->accept(*this);
-          this->set_variable_prefix(saved_prefix);
+          accept_without_prefix(array_var->subscripted_variable);
           s4o.print(".value.table");
           current_array_type = array_type;
           array_var->subscript_list->accept(*this);
@@ -317,11 +318,8 @@ void *print_setter(symbol_c* symbol,
         // It is my (MJS) conviction that by this time the following will always be true...
         //   wanted_variablegeneration == expression_vg;
         // For complex FB expressions (like array elements), we need to print them directly
-        // without going through print_getter, so we temporarily set variable_prefix to NULL
-        const char *saved_prefix = this->get_variable_prefix();
-        this->set_variable_prefix(NULL);
-        fb_symbol->accept(*this);
-        this->set_variable_prefix(saved_prefix);
+        // without going through print_getter
+        accept_without_prefix(fb_symbol);
         s4o.print(".,");
         symbol->accept(*this);
     }
@@ -1160,11 +1158,8 @@ void *visit(fb_invocation_c *symbol) {
     s4o.print("&");
   print_variable_prefix();
   // For complex FB expressions (like array elements), we need to print them directly
-  // without going through print_getter, so we temporarily set variable_prefix to NULL
-  const char *saved_prefix = this->get_variable_prefix();
-  this->set_variable_prefix(NULL);
-  symbol->fb_name->accept(*this);
-  this->set_variable_prefix(saved_prefix);
+  // without going through print_getter
+  accept_without_prefix(symbol->fb_name);
   s4o.print(")");
 
   /* loop through each function parameter, find the variable to which

--- a/stage4/generate_c/generate_c_st.cc
+++ b/stage4/generate_c/generate_c_st.cc
@@ -120,42 +120,63 @@ class generate_c_st_c: public generate_c_base_and_typeid_c {
 
 
 void *print_getter(symbol_c *symbol) {
-  // SPECIAL CASE: Field access on FB array element (e.g., result := TON_ARR[1].Q)
-  // FB array elements are raw structs (not wrappers), but their fields are wrappers.
-  // We need to emit raw C code: data__->TON_ARR.value.table[idx].FIELD.value
-  // We cannot use __GET_VAR macro because it expects a wrapper type variable as the name parameter,
-  // but data__->TON_ARR.value.table[idx] is a raw FB struct, not a wrapper.
+  // Special case: FB array element field access (e.g., TON_ARR[1].Q)
+  // For forced variables to work correctly, we need to make the field be the "name" parameter
+  // so the macro checks the field's .flags, not the array's .flags.
+  // Generate: __GET_VAR(data__->TON_ARR.value.table[idx]., Q, )
   structured_variable_c *structured_var = dynamic_cast<structured_variable_c *>(symbol);
   if (structured_var != NULL) {
     array_variable_c *array_var = dynamic_cast<array_variable_c *>(structured_var->record_variable);
     if (array_var != NULL) {
-      // Get the array type, then get the element type from it
+      // Get the array element type
       symbol_c *array_type = search_varfb_instance_type->get_basetype_decl(array_var->subscripted_variable);
       symbol_c *array_element_type = get_datatype_info_c::get_array_storedtype_id(array_type);
+      
+      // Check if the array element is a function block
       if (array_element_type != NULL && get_datatype_info_c::is_function_block(array_element_type)) {
-        // Emit raw C code: data__->ARRAY.value.table[idx].FIELD.value
+        // Generate the macro with field as the "name" parameter
+        unsigned int vartype = analyse_variable_c::first_nonfb_vardecltype(symbol, scope_);
+        
         if (wanted_variablegeneration == fparam_output_vg) {
-          // For output parameters, emit address: &(data__->ARRAY.value.table[idx].FIELD.value)
-          s4o.print("&(");
+          if (vartype == search_var_instance_decl_c::external_vt)
+            s4o.print(GET_EXTERNAL_BY_REF);
+          else if (vartype == search_var_instance_decl_c::located_vt)
+            s4o.print(GET_LOCATED_BY_REF);
+          else
+            s4o.print(GET_VAR_BY_REF);
         }
+        else {
+          if (vartype == search_var_instance_decl_c::external_vt)
+            s4o.print(GET_EXTERNAL);
+          else if (vartype == search_var_instance_decl_c::located_vt)
+            s4o.print(GET_LOCATED);
+          else
+            s4o.print(GET_VAR);
+        }
+        
+        s4o.print("(");
         print_variable_prefix();
+        // Print the array access with .value.table[idx].FIELD (without trailing dot)
+        // The __GET_VAR macro will add .value to access the raw value
+        // Temporarily disable variable_prefix to avoid nested __GET_VAR calls
         const char *saved_prefix = this->get_variable_prefix();
         this->set_variable_prefix(NULL);
-        wanted_variablegeneration = expression_vg;
-        array_var->accept(*this);
-        s4o.print(".");
-        structured_var->field_selector->accept(*this);
-        s4o.print(".value");
+        array_var->subscripted_variable->accept(*this);
         this->set_variable_prefix(saved_prefix);
-        if (wanted_variablegeneration == fparam_output_vg) {
-          s4o.print(")");
-        }
-        wanted_variablegeneration = expression_vg;
+        s4o.print(".value.table");
+        current_array_type = array_type;
+        array_var->subscript_list->accept(*this);
+        current_array_type = NULL;
+        s4o.print(".");
+        // Print the field name
+        structured_var->field_selector->accept(*this);
+        s4o.print(",)");
         return NULL;
       }
     }
   }
-
+  
+  // Default case: use standard macro generation
   unsigned int vartype = analyse_variable_c::first_nonfb_vardecltype(symbol, scope_);
   if (wanted_variablegeneration == fparam_output_vg) {
     if (vartype == search_var_instance_decl_c::external_vt) {
@@ -205,38 +226,59 @@ void *print_setter(symbol_c* symbol,
         symbol_c* fb_symbol = NULL,
         symbol_c* fb_value = NULL) {
  
-  // SPECIAL CASE: Field access on FB array element (e.g., TON_ARR[1].IN := value)
-  // FB array elements are raw structs (not wrappers), but their fields are wrappers.
-  // We need to emit raw C code: data__->TON_ARR.value.table[idx].FIELD.value = value
-  // We cannot use __SET_VAR macro because it expects a wrapper type variable as the name parameter,
-  // but data__->TON_ARR.value.table[idx] is a raw FB struct, not a wrapper.
-  structured_variable_c *structured_var = dynamic_cast<structured_variable_c *>(symbol);
-  if (fb_symbol == NULL && structured_var != NULL) {
-    array_variable_c *array_var = dynamic_cast<array_variable_c *>(structured_var->record_variable);
-    if (array_var != NULL) {
-      // Get the array type, then get the element type from it
-      symbol_c *array_type = search_varfb_instance_type->get_basetype_decl(array_var->subscripted_variable);
-      symbol_c *array_element_type = get_datatype_info_c::get_array_storedtype_id(array_type);
-      if (array_element_type != NULL && get_datatype_info_c::is_function_block(array_element_type)) {
-        // Emit raw C code: data__->ARRAY.value.table[idx].FIELD.value = value
-        print_variable_prefix();
-        const char *saved_prefix = this->get_variable_prefix();
-        this->set_variable_prefix(NULL);
-        wanted_variablegeneration = expression_vg;
-        array_var->accept(*this);
-        s4o.print(".");
-        structured_var->field_selector->accept(*this);
-        s4o.print(".value = ");
-        this->set_variable_prefix(saved_prefix);
-        // Emit the value expression
-        wanted_variablegeneration = expression_vg;
-        print_check_function(type, value, fb_value);
-        wanted_variablegeneration = expression_vg;
-        return NULL;
+  // Special case: FB array element field access (e.g., TON_ARR[1].IN := value)
+  // For forced variables to work correctly, we need to make the field be the "name" parameter
+  // so the macro checks the field's .flags, not the array's .flags.
+  // Generate: __SET_VAR(data__->TON_ARR.value.table[idx]., IN, , value)
+  if (fb_symbol == NULL) {
+    structured_variable_c *structured_var = dynamic_cast<structured_variable_c *>(symbol);
+    if (structured_var != NULL) {
+      array_variable_c *array_var = dynamic_cast<array_variable_c *>(structured_var->record_variable);
+      if (array_var != NULL) {
+        // Get the array element type
+        symbol_c *array_type = search_varfb_instance_type->get_basetype_decl(array_var->subscripted_variable);
+        symbol_c *array_element_type = get_datatype_info_c::get_array_storedtype_id(array_type);
+        
+        // Check if the array element is a function block
+        if (array_element_type != NULL && get_datatype_info_c::is_function_block(array_element_type)) {
+          // Generate the macro with field as the "name" parameter
+          unsigned int vartype = analyse_variable_c::first_nonfb_vardecltype(symbol, scope_);
+          
+          if (vartype == search_var_instance_decl_c::external_vt)
+            s4o.print(SET_EXTERNAL);
+          else if (vartype == search_var_instance_decl_c::located_vt)
+            s4o.print(SET_LOCATED);
+          else
+            s4o.print(SET_VAR);
+          
+          s4o.print("(");
+          print_variable_prefix();
+          // Print the array access with .value.table[idx]. (with trailing dot)
+          // Temporarily disable variable_prefix to avoid nested __SET_VAR calls
+          const char *saved_prefix = this->get_variable_prefix();
+          this->set_variable_prefix(NULL);
+          array_var->subscripted_variable->accept(*this);
+          this->set_variable_prefix(saved_prefix);
+          s4o.print(".value.table");
+          current_array_type = array_type;
+          array_var->subscript_list->accept(*this);
+          current_array_type = NULL;
+          s4o.print(".,");
+          // Print the field name (this becomes the "name" parameter)
+          structured_var->field_selector->accept(*this);
+          s4o.print(",,");
+          // Print the value
+          wanted_variablegeneration = expression_vg;
+          print_check_function(type, value, fb_value);
+          s4o.print(")");
+          wanted_variablegeneration = expression_vg;
+          return NULL;
+        }
       }
     }
   }
-
+  
+  // Default case: use standard macro generation
   unsigned int vartype;
   if (fb_symbol == NULL) {
     vartype = analyse_variable_c::first_nonfb_vardecltype(symbol, scope_);

--- a/stage4/generate_c/generate_c_st.cc
+++ b/stage4/generate_c/generate_c_st.cc
@@ -120,6 +120,42 @@ class generate_c_st_c: public generate_c_base_and_typeid_c {
 
 
 void *print_getter(symbol_c *symbol) {
+  // SPECIAL CASE: Field access on FB array element (e.g., result := TON_ARR[1].Q)
+  // FB array elements are raw structs (not wrappers), but their fields are wrappers.
+  // We need to emit raw C code: data__->TON_ARR.value.table[idx].FIELD.value
+  // We cannot use __GET_VAR macro because it expects a wrapper type variable as the name parameter,
+  // but data__->TON_ARR.value.table[idx] is a raw FB struct, not a wrapper.
+  structured_variable_c *structured_var = dynamic_cast<structured_variable_c *>(symbol);
+  if (structured_var != NULL) {
+    array_variable_c *array_var = dynamic_cast<array_variable_c *>(structured_var->record_variable);
+    if (array_var != NULL) {
+      // Get the array type, then get the element type from it
+      symbol_c *array_type = search_varfb_instance_type->get_basetype_decl(array_var->subscripted_variable);
+      symbol_c *array_element_type = get_datatype_info_c::get_array_storedtype_id(array_type);
+      if (array_element_type != NULL && get_datatype_info_c::is_function_block(array_element_type)) {
+        // Emit raw C code: data__->ARRAY.value.table[idx].FIELD.value
+        if (wanted_variablegeneration == fparam_output_vg) {
+          // For output parameters, emit address: &(data__->ARRAY.value.table[idx].FIELD.value)
+          s4o.print("&(");
+        }
+        print_variable_prefix();
+        const char *saved_prefix = this->get_variable_prefix();
+        this->set_variable_prefix(NULL);
+        wanted_variablegeneration = expression_vg;
+        array_var->accept(*this);
+        s4o.print(".");
+        structured_var->field_selector->accept(*this);
+        s4o.print(".value");
+        this->set_variable_prefix(saved_prefix);
+        if (wanted_variablegeneration == fparam_output_vg) {
+          s4o.print(")");
+        }
+        wanted_variablegeneration = expression_vg;
+        return NULL;
+      }
+    }
+  }
+
   unsigned int vartype = analyse_variable_c::first_nonfb_vardecltype(symbol, scope_);
   if (wanted_variablegeneration == fparam_output_vg) {
     if (vartype == search_var_instance_decl_c::external_vt) {
@@ -169,6 +205,38 @@ void *print_setter(symbol_c* symbol,
         symbol_c* fb_symbol = NULL,
         symbol_c* fb_value = NULL) {
  
+  // SPECIAL CASE: Field access on FB array element (e.g., TON_ARR[1].IN := value)
+  // FB array elements are raw structs (not wrappers), but their fields are wrappers.
+  // We need to emit raw C code: data__->TON_ARR.value.table[idx].FIELD.value = value
+  // We cannot use __SET_VAR macro because it expects a wrapper type variable as the name parameter,
+  // but data__->TON_ARR.value.table[idx] is a raw FB struct, not a wrapper.
+  structured_variable_c *structured_var = dynamic_cast<structured_variable_c *>(symbol);
+  if (fb_symbol == NULL && structured_var != NULL) {
+    array_variable_c *array_var = dynamic_cast<array_variable_c *>(structured_var->record_variable);
+    if (array_var != NULL) {
+      // Get the array type, then get the element type from it
+      symbol_c *array_type = search_varfb_instance_type->get_basetype_decl(array_var->subscripted_variable);
+      symbol_c *array_element_type = get_datatype_info_c::get_array_storedtype_id(array_type);
+      if (array_element_type != NULL && get_datatype_info_c::is_function_block(array_element_type)) {
+        // Emit raw C code: data__->ARRAY.value.table[idx].FIELD.value = value
+        print_variable_prefix();
+        const char *saved_prefix = this->get_variable_prefix();
+        this->set_variable_prefix(NULL);
+        wanted_variablegeneration = expression_vg;
+        array_var->accept(*this);
+        s4o.print(".");
+        structured_var->field_selector->accept(*this);
+        s4o.print(".value = ");
+        this->set_variable_prefix(saved_prefix);
+        // Emit the value expression
+        wanted_variablegeneration = expression_vg;
+        print_check_function(type, value, fb_value);
+        wanted_variablegeneration = expression_vg;
+        return NULL;
+      }
+    }
+  }
+
   unsigned int vartype;
   if (fb_symbol == NULL) {
     vartype = analyse_variable_c::first_nonfb_vardecltype(symbol, scope_);

--- a/stage4/generate_c/generate_c_typedecl.cc
+++ b/stage4/generate_c/generate_c_typedecl.cc
@@ -555,17 +555,45 @@ void *visit(array_type_declaration_c *symbol) {
     goto end; // already defined. No need to define it again!!
   datatypes_already_defined[id->value] = 1; // insert this datatype into the list of already defined arrays!
   
-  current_typedefinition = array_td;
-  current_type_name = id;
+  {
+    current_typedefinition = array_td;
+    current_type_name = id;
 
-  s4o_incl.print("__DECLARE_ARRAY_TYPE(");
-  current_type_name->accept(*generate_c_typeid);
-  s4o_incl.print(",");
-  symbol->array_spec_init->accept(*this); // always calls array_spec_init_c
-  s4o_incl.print(")\n");
+    // Determine if we need to use __DECLARE_ARRAY_TYPE_WRAPPER for base type arrays
+    // Extract the base type from the array specification
+    symbol_c *base_type = NULL;
+    array_spec_init_c *array_spec_init = dynamic_cast<array_spec_init_c *>(symbol->array_spec_init);
+    if (array_spec_init != NULL) {
+      array_specification_c *array_spec = dynamic_cast<array_specification_c *>(array_spec_init->array_specification);
+      if (array_spec != NULL) {
+        base_type = array_spec->non_generic_type_name;
+      }
+    }
+    
+    // Check if base type is elementary (use wrapper) or function block (no wrapper)
+    bool use_wrapper_macro = false;
+    if (base_type != NULL) {
+      // Get the actual type (resolve any derived type aliases)
+      symbol_c *base_type_decl = search_base_type_c::get_basetype_decl(base_type);
+      if (base_type_decl != NULL) {
+        // Use wrapper macro for elementary types, regular macro for FBs
+        use_wrapper_macro = get_datatype_info_c::is_ANY_ELEMENTARY(base_type_decl);
+      }
+    }
 
-  current_type_name = NULL;
-  current_typedefinition = none_td;
+    if (use_wrapper_macro) {
+      s4o_incl.print("__DECLARE_ARRAY_TYPE_WRAPPER(");
+    } else {
+      s4o_incl.print("__DECLARE_ARRAY_TYPE(");
+    }
+    current_type_name->accept(*generate_c_typeid);
+    s4o_incl.print(",");
+    symbol->array_spec_init->accept(*this); // always calls array_spec_init_c
+    s4o_incl.print(")\n");
+
+    current_type_name = NULL;
+    current_typedefinition = none_td;
+  }
 
 end:  
   symbol                 ->anotations_map["generate_c_annotaton__implicit_type_id"] = id;

--- a/stage4/generate_c/generate_c_vardecl.cc
+++ b/stage4/generate_c/generate_c_vardecl.cc
@@ -162,17 +162,27 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
       
       init_array_size(array_specification);
       
-      // Check if the array base type is a function block
+      // Check if the array base type is a function block or elementary type
       bool is_fb_array = false;
+      bool is_elementary_array = false;
       if (array_base_type != NULL) {
         is_fb_array = get_datatype_info_c::is_function_block(array_base_type);
+        is_elementary_array = get_datatype_info_c::is_ANY_ELEMENTARY(array_base_type);
       }
       
       if (is_fb_array) {
         // Generate loop-based initialization for FB arrays
         init_fb_array(var1_list, array_specification, array_initialization);
+      } else if (is_elementary_array) {
+        // For elementary arrays with wrapper elements, we can't use static const initialization
+        // because the wrapper elements need their .value fields initialized.
+        // However, if there's no explicit initialization, we can skip generating initialization code
+        // since the default initialization will be handled by the C compiler (zero-initialization).
+        // If there IS explicit initialization, we would need loop-based initialization,
+        // but for now we'll just skip it and rely on runtime assignments.
+        // TODO: Implement loop-based initialization for elementary arrays with explicit initial values
       } else {
-        // Generate static const initialization for elementary type arrays
+        // Generate static const initialization for non-elementary, non-FB arrays (e.g., structures)
         s4o.print("\n");
         s4o.print(s4o.indent_spaces + "{\n");
         s4o.indent_right();

--- a/stage4/generate_c/generate_c_vardecl.cc
+++ b/stage4/generate_c/generate_c_vardecl.cc
@@ -157,10 +157,135 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
       }
     }
 
+    void init_elementary_array(symbol_c *var1_list, symbol_c *array_specification, symbol_c *array_initialization) {
+      // Generate loop-based initialization for elementary arrays with wrapper elements
+      // For an array like ARRAY [1..3] OF INT := [10, 20, 30], generate:
+      // {
+      //   __SET_VAR(, data__->INT_ARR.value.table[0], , 10);
+      //   __SET_VAR(, data__->INT_ARR.value.table[1], , 20);
+      //   __SET_VAR(, data__->INT_ARR.value.table[2], , 30);
+      // }
+      
+      list_c *list = dynamic_cast<list_c *>(var1_list);
+      if (list == NULL) ERROR;
+      
+      // Flatten initialization values into a vector
+      std::vector<symbol_c*> values;
+      
+      // Use array_default_initialization which was set by init_array_size() via the array_spec_init_c visitor
+      // This contains the actual initialization values from the IEC code
+      symbol_c *init_values = array_default_initialization;
+      
+      // init_values should be the array_initial_elements_list_c
+      array_initial_elements_list_c *init_list = dynamic_cast<array_initial_elements_list_c *>(init_values);
+      
+      if (init_list != NULL) {
+        for (int i = 0; i < init_list->n && values.size() < array_size; i++) {
+          symbol_c *list_elem = init_list->get_element(i);
+          array_initial_elements_c *init_elem = dynamic_cast<array_initial_elements_c *>(list_elem);
+          
+          if (init_elem != NULL) {
+            // This is an array_initial_elements_c node (e.g., "2(10)" with explicit repetition)
+            // Extract repetition count from integer
+            unsigned long long int repetition_count = 1;
+            if (init_elem->integer != NULL) {
+              if (VALID_CVALUE(int64, init_elem->integer) && (GET_CVALUE(int64, init_elem->integer) >= 0))
+                repetition_count = GET_CVALUE(int64, init_elem->integer);
+              else if (VALID_CVALUE(uint64, init_elem->integer))
+                repetition_count = GET_CVALUE(uint64, init_elem->integer);
+              // If integer doesn't have a CVALUE, it means repetition count is 1 (implicit)
+            }
+            
+            // Get the value expression (or use default if NULL)
+            symbol_c *expr = (init_elem->array_initial_element != NULL) ? 
+                             init_elem->array_initial_element : array_default_value;
+            
+            // Add this expression repetition_count times (up to array_size)
+            for (unsigned long long int j = 0; j < repetition_count && values.size() < array_size; j++) {
+              values.push_back(expr);
+            }
+          } else {
+            // This is a direct value expression (e.g., "10" in "[10, 20, 30]")
+            // For simple array initialization, the parser creates value expressions directly
+            // without wrapping them in array_initial_elements_c
+            values.push_back(list_elem);
+          }
+        }
+      }else {
+        // If array_initialization is not array_initial_elements_list_c, it might be a single value
+        // or some other form. For now, just use default values.
+        // This handles cases where the initialization is not in the expected format.
+      }
+      
+      // Generate initialization code for each variable in var1_list
+      for (int var_idx = 0; var_idx < list->n; var_idx++) {
+        s4o.print("\n");
+        s4o.print(s4o.indent_spaces);
+        s4o.print("{\n");
+        s4o.indent_right();
+        
+        // Emit __SET_VAR assignments for explicit values
+        for (size_t i = 0; i < values.size(); i++) {
+          s4o.print(s4o.indent_spaces);
+          s4o.print(SET_VAR);
+          s4o.print("(,");
+          print_variable_prefix();
+          current_mode = none_am;
+          list->get_element(var_idx)->accept(*this);
+          s4o.print(".value.table[");
+          char idx_str[32];
+          snprintf(idx_str, sizeof(idx_str), "%zu", i);
+          s4o.print(idx_str);
+          s4o.print("],,");
+          // Print the value expression using initializationvalue_am mode
+          current_mode = initializationvalue_am;
+          values[i]->accept(*this);
+          current_mode = none_am;
+          s4o.print(");\n");
+        }
+        
+        // Fill remaining elements with default value
+        for (unsigned long long int i = values.size(); i < array_size; i++) {
+          s4o.print(s4o.indent_spaces);
+          s4o.print(SET_VAR);
+          s4o.print("(,");
+          print_variable_prefix();
+          current_mode = none_am;
+          list->get_element(var_idx)->accept(*this);
+          s4o.print(".value.table[");
+          char idx_str[32];
+          snprintf(idx_str, sizeof(idx_str), "%llu", i);
+          s4o.print(idx_str);
+          s4o.print("],,");
+          // Print the default value expression using initializationvalue_am mode
+          current_mode = initializationvalue_am;
+          array_default_value->accept(*this);
+          current_mode = none_am;
+          s4o.print(");\n");
+        }
+        
+        s4o.indent_left();
+        s4o.print(s4o.indent_spaces);
+        s4o.print("}");
+      }
+    }
+
     void init_array(symbol_c *var1_list, symbol_c *array_specification, symbol_c *array_initialization) {
       int i;
       
+      // Call init_array_size first (it resets array_default_initialization to NULL)
       init_array_size(array_specification);
+      
+      // Then extract and set the initialization values AFTER init_array_size
+      // array_initialization might be array_spec_init_c, so extract the array_initialization field
+      if (array_initialization != NULL) {
+        array_spec_init_c *array_spec_init = dynamic_cast<array_spec_init_c *>(array_initialization);
+        if (array_spec_init != NULL) {
+          set_array_default_initialisation(array_spec_init->array_initialization);
+        } else {
+          set_array_default_initialisation(array_initialization);
+        }
+      }
       
       // Check if the array base type is a function block or elementary type
       bool is_fb_array = false;
@@ -176,11 +301,12 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
       } else if (is_elementary_array) {
         // For elementary arrays with wrapper elements, we can't use static const initialization
         // because the wrapper elements need their .value fields initialized.
-        // However, if there's no explicit initialization, we can skip generating initialization code
+        // If there's explicit initialization, use loop-based initialization with __SET_VAR.
+        // If there's no explicit initialization, skip generating initialization code
         // since the default initialization will be handled by the C compiler (zero-initialization).
-        // If there IS explicit initialization, we would need loop-based initialization,
-        // but for now we'll just skip it and rely on runtime assignments.
-        // TODO: Implement loop-based initialization for elementary arrays with explicit initial values
+        if (array_initialization != NULL) {
+          init_elementary_array(var1_list, array_specification, array_initialization);
+        }
       } else {
         // Generate static const initialization for non-elementary, non-FB arrays (e.g., structures)
         s4o.print("\n");

--- a/stage4/generate_c/generate_c_vardecl.cc
+++ b/stage4/generate_c/generate_c_vardecl.cc
@@ -81,10 +81,17 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
     unsigned long long int array_size;
     unsigned long long int defined_values_count;
     unsigned long long int current_initialization_count;
+    unsigned int current_varqualifier;
 
   public:
-    generate_c_array_initialization_c(stage4out_c *s4o_ptr): generate_c_base_and_typeid_c(s4o_ptr) {}
+    generate_c_array_initialization_c(stage4out_c *s4o_ptr): generate_c_base_and_typeid_c(s4o_ptr) {
+      current_varqualifier = 0;  // none_vq
+    }
     ~generate_c_array_initialization_c(void) {}
+
+    void set_varqualifier(unsigned int varqualifier) {
+      current_varqualifier = varqualifier;
+    }
 
     void init_array_size(symbol_c *array_specification) {
       array_size = 1;
@@ -100,27 +107,85 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
       array_default_initialization = array_initialization;
     }
 
+    void init_fb_array(symbol_c *var1_list, symbol_c *array_specification, symbol_c *array_initialization) {
+      // Generate loop-based initialization for function block arrays
+      // For an array like ARRAY [1..2] OF TON, generate:
+      // for (int __i = 0; __i < 2; __i++) {
+      //   TON_init__(&data__->SOMETHING.table[__i], retain);
+      // }
+      
+      list_c *list = dynamic_cast<list_c *>(var1_list);
+      if (list == NULL) ERROR;
+      
+      for (int i = 0; i < list->n; i++) {
+        s4o.print("\n");
+        s4o.print(s4o.indent_spaces);
+        s4o.print("for (int __i = 0; __i < ");
+        // Print the array size
+        char size_str[32];
+        snprintf(size_str, sizeof(size_str), "%llu", array_size);
+        s4o.print(size_str);
+        s4o.print("; __i++) {\n");
+        s4o.indent_right();
+        s4o.print(s4o.indent_spaces);
+        
+        // Generate the FB init call: FB_TYPE_init__(&array.table[__i], retain);
+        array_base_type->accept(*this);
+        s4o.print(FB_INIT_SUFFIX);
+        s4o.print("(&");
+        print_variable_prefix();
+        list->get_element(i)->accept(*this);
+        s4o.print(".table[__i]");
+        
+        // Print retain parameter
+        if (current_varqualifier & 0x0002) {  // retain_vq
+          s4o.print(",1");
+        } else if (current_varqualifier & 0x0004) {  // non_retain_vq
+          s4o.print(",0");
+        } else {
+          s4o.print(",retain");
+        }
+        
+        s4o.print(");\n");
+        s4o.indent_left();
+        s4o.print(s4o.indent_spaces);
+        s4o.print("}");
+      }
+    }
+
     void init_array(symbol_c *var1_list, symbol_c *array_specification, symbol_c *array_initialization) {
       int i;
       
       init_array_size(array_specification);
       
-      s4o.print("\n");
-      s4o.print(s4o.indent_spaces + "{\n");
-      s4o.indent_right();
-      s4o.print(s4o.indent_spaces);
-      s4o.print("static const ");
+      // Check if the array base type is a function block
+      bool is_fb_array = false;
+      if (array_base_type != NULL) {
+        is_fb_array = get_datatype_info_c::is_function_block(array_base_type);
+      }
+      
+      if (is_fb_array) {
+        // Generate loop-based initialization for FB arrays
+        init_fb_array(var1_list, array_specification, array_initialization);
+      } else {
+        // Generate static const initialization for elementary type arrays
+        s4o.print("\n");
+        s4o.print(s4o.indent_spaces + "{\n");
+        s4o.indent_right();
+        s4o.print(s4o.indent_spaces);
+        s4o.print("static const ");
 
-      current_mode = typedecl_am;
-      array_specification->accept(*this);
-      s4o.print(" temp = ");
+        current_mode = typedecl_am;
+        array_specification->accept(*this);
+        s4o.print(" temp = ");
 
-      init_array_values(array_initialization);
+        init_array_values(array_initialization);
 
-      s4o.print(";\n");
-      var1_list->accept(*this);
-      s4o.indent_left();
-      s4o.print(s4o.indent_spaces + "}");
+        s4o.print(";\n");
+        var1_list->accept(*this);
+        s4o.indent_left();
+        s4o.print(s4o.indent_spaces + "}");
+      }
     }
     
     void init_array_values(symbol_c *array_initialization) {
@@ -1493,6 +1558,7 @@ void *visit(array_var_init_decl_c *symbol) {
   if (wanted_varformat == constructorinit_vf) {
     generate_c_array_initialization_c *array_initialization = new generate_c_array_initialization_c(&s4o);
     array_initialization->set_variable_prefix(get_variable_prefix());
+    array_initialization->set_varqualifier(this->current_varqualifier);
     array_initialization->init_array(symbol->var1_list, this->current_var_type_symbol, this->current_var_init_symbol);
     delete array_initialization;
   }
@@ -1635,6 +1701,7 @@ void *visit(array_var_declaration_c *symbol) {
   if (wanted_varformat == constructorinit_vf) {
     generate_c_array_initialization_c *array_initialization = new generate_c_array_initialization_c(&s4o);
     array_initialization->set_variable_prefix(get_variable_prefix());
+    array_initialization->set_varqualifier(this->current_varqualifier);
     array_initialization->init_array(symbol->var1_list, this->current_var_type_symbol, this->current_var_init_symbol);
     delete array_initialization;
   }

--- a/stage4/generate_c/generate_c_vardecl.cc
+++ b/stage4/generate_c/generate_c_vardecl.cc
@@ -129,7 +129,9 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
         s4o.indent_right();
         s4o.print(s4o.indent_spaces);
         
-        // Generate the FB init call: FB_TYPE_init__(&data__->VARNAME.table[__i], retain);
+        // Generate the FB init call: FB_TYPE_init__(&data__->VARNAME.value.table[__i], retain);
+        // Note: .value is needed because __DECLARE_VAR creates a wrapper type __IEC_<type>_t
+        // with a .value field containing the actual array struct
         array_base_type->accept(*this);
         s4o.print(FB_INIT_SUFFIX);
         s4o.print("(&");
@@ -137,7 +139,7 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
         // Set mode to print the variable name correctly
         current_mode = none_am;
         list->get_element(i)->accept(*this);
-        s4o.print(".table[__i]");
+        s4o.print(".value.table[__i]");
         
         // Print retain parameter
         if (current_varqualifier & 0x0002) {  // retain_vq

--- a/stage4/generate_c/generate_c_vardecl.cc
+++ b/stage4/generate_c/generate_c_vardecl.cc
@@ -129,11 +129,13 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
         s4o.indent_right();
         s4o.print(s4o.indent_spaces);
         
-        // Generate the FB init call: FB_TYPE_init__(&array.table[__i], retain);
+        // Generate the FB init call: FB_TYPE_init__(&data__->VARNAME.table[__i], retain);
         array_base_type->accept(*this);
         s4o.print(FB_INIT_SUFFIX);
         s4o.print("(&");
         print_variable_prefix();
+        // Set mode to print the variable name correctly
+        current_mode = none_am;
         list->get_element(i)->accept(*this);
         s4o.print(".table[__i]");
         
@@ -214,7 +216,13 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
         case arraysize_am:
           /* look up the type declaration... */
           iter = type_symtable.find(type_name);
-          if (iter == type_symtable.end())   ERROR;  // Type declaration not found!!
+          if (iter == type_symtable.end()) {
+            // Type not found in type_symtable. This could be a standard library
+            // function block (like TON, CTU, etc.) which are stored in 
+            // library_element_symtable (not accessible from here).
+            // Return NULL and let the caller handle it appropriately.
+            return NULL;
+          }
           iter->second->accept(*this);  // iter->second is a type_decl
           break;
         default:
@@ -263,8 +271,14 @@ class generate_c_array_initialization_c: public generate_c_base_and_typeid_c {
         case arraysize_am:
           symbol->array_subrange_list->accept(*this);
           array_base_type = symbol->non_generic_type_name;
-          array_default_value = type_initial_value_c::get(symbol->non_generic_type_name);
-          if (array_default_value == NULL) ERROR;
+          // For function block arrays, we don't need a default value
+          // because they use loop-based initialization with FB_TYPE_init__()
+          if (get_datatype_info_c::is_function_block(array_base_type)) {
+            array_default_value = NULL;  // FBs don't have simple default values
+          } else {
+            array_default_value = type_initial_value_c::get(symbol->non_generic_type_name);
+            if (array_default_value == NULL) ERROR;
+          }
           break;
         case typedecl_am: {
             int implicit_id_count = symbol->anotations_map.count("generate_c_annotaton__implicit_type_id");

--- a/stage4/generate_c/generate_var_list.cc
+++ b/stage4/generate_c/generate_var_list.cc
@@ -209,6 +209,31 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
     typedef struct {
       symbol_c *symbol;
     } SYMBOL;
+    
+    /* Helper class to represent an array element access in the symbol list */
+    class array_element_symbol_c : public symbol_c {
+      public:
+        symbol_c *array_var;
+        std::vector<int> indices;
+        stage4out_c *s4o_ptr;
+        
+        array_element_symbol_c(symbol_c *var, const std::vector<int> &idx, stage4out_c *s4o) 
+          : array_var(var), indices(idx), s4o_ptr(s4o) {}
+        
+        virtual void *accept(visitor_c &visitor) {
+          // When visited, print the array variable name followed by subscripts
+          array_var->accept(visitor);
+          s4o_ptr->print(".value.table[");
+          for (size_t i = 0; i < indices.size(); i++) {
+            if (i > 0) s4o_ptr->print("][");
+            char idx_str[32];
+            sprintf(idx_str, "%d", indices[i] - 1); // Convert to 0-based index
+            s4o_ptr->print(idx_str);
+          }
+          s4o_ptr->print("]");
+          return NULL;
+        }
+    };
 
     typedef enum {
       none_dt,
@@ -295,11 +320,184 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
       }
     }
     
+    /* Helper function to recursively generate array element entries */
+    void declare_array_elements_recursive(symbol_c *var_name, symbol_c *array_spec, 
+                                          std::vector<int> &indices, int dimension) {
+      array_specification_c *array = dynamic_cast<array_specification_c *>(array_spec);
+      if (array == NULL) ERROR;
+      
+      array_subrange_list_c *subrange_list = dynamic_cast<array_subrange_list_c *>(array->array_subrange_list);
+      if (subrange_list == NULL) ERROR;
+      
+      // Get the subrange for this dimension
+      if (dimension >= subrange_list->n) ERROR;
+      subrange_c *subrange = dynamic_cast<subrange_c *>(subrange_list->get_element(dimension));
+      if (subrange == NULL) ERROR;
+      
+      // Extract lower and upper bounds
+      int64_t lower_bound = 0;
+      int64_t upper_bound = 0;
+      
+      if (subrange->lower_limit->const_value._int64.is_valid()) {
+        lower_bound = subrange->lower_limit->const_value._int64.get();
+      } else if (subrange->lower_limit->const_value._uint64.is_valid()) {
+        lower_bound = (int64_t)subrange->lower_limit->const_value._uint64.get();
+      } else {
+        ERROR; // Array bounds must be constant
+      }
+      
+      if (subrange->upper_limit->const_value._int64.is_valid()) {
+        upper_bound = subrange->upper_limit->const_value._int64.get();
+      } else if (subrange->upper_limit->const_value._uint64.is_valid()) {
+        upper_bound = (int64_t)subrange->upper_limit->const_value._uint64.get();
+      } else {
+        ERROR; // Array bounds must be constant
+      }
+      
+      // Iterate through this dimension
+      for (int64_t i = lower_bound; i <= upper_bound; i++) {
+        indices.push_back((int)i);
+        
+        if (dimension == subrange_list->n - 1) {
+          // Last dimension - generate the entry
+          declare_array_element_entry(var_name, array, indices);
+        } else {
+          // Recurse to next dimension
+          declare_array_elements_recursive(var_name, array_spec, indices, dimension + 1);
+        }
+        
+        indices.pop_back();
+      }
+    }
+    
+    /* Helper function to generate FB field entries for an array element */
+    void declare_fb_array_element_fields(symbol_c *var_name, symbol_c *fb_type, 
+                                         std::vector<int> &indices) {
+      // Get the FB type declaration
+      function_block_declaration_c *fb_decl = dynamic_cast<function_block_declaration_c *>(fb_type);
+      if (fb_decl == NULL) {
+        // Try to get it from the type name
+        fb_decl = dynamic_cast<function_block_declaration_c *>(
+          search_base_type_c::get_basetype_decl(fb_type));
+      }
+      
+      if (fb_decl == NULL) return; // Not a user-defined FB, might be standard FB
+      
+      // Visit the FB declaration to generate field entries
+      // We need to temporarily add the array element to the symbol list
+      array_element_symbol_c *array_elem = new array_element_symbol_c(var_name, indices, &s4o);
+      SYMBOL *current_name = new SYMBOL;
+      current_name->symbol = array_elem;
+      current_symbol_list.push_back(*current_name);
+      
+      // Visit the FB type to generate field entries
+      fb_decl->accept(*this);
+      
+      current_symbol_list.pop_back();
+      delete current_name;
+      delete array_elem;
+    }
+    
+    /* Helper function to generate a single array element entry */
+    void declare_array_element_entry(symbol_c *var_name, array_specification_c *array_spec,
+                                     std::vector<int> &indices) {
+      // Get the element type
+      symbol_c *element_type = search_base_type_c::get_basetype_decl(array_spec->non_generic_type_name);
+      if (element_type == NULL) ERROR;
+      
+      // Check if element is a function block
+      bool is_fb = get_datatype_info_c::is_function_block(element_type);
+      
+      if (is_fb) {
+        // For FB arrays, generate entry for the FB instance and then its fields
+        // First, generate the FB instance entry
+        print_var_number();
+        s4o.print(";FB;");
+        print_symbol_list();
+        var_name->accept(*this);
+        s4o.print(".value.table[");
+        for (size_t i = 0; i < indices.size(); i++) {
+          if (i > 0) s4o.print("][");
+          char idx_str[32];
+          sprintf(idx_str, "%d", indices[i] - 1); // Convert to 0-based index
+          s4o.print(idx_str);
+        }
+        s4o.print("];");
+        print_symbol_list();
+        var_name->accept(*this);
+        s4o.print(".value.table[");
+        for (size_t i = 0; i < indices.size(); i++) {
+          if (i > 0) s4o.print("][");
+          char idx_str[32];
+          sprintf(idx_str, "%d", indices[i] - 1);
+          s4o.print(idx_str);
+        }
+        s4o.print("];");
+        array_spec->non_generic_type_name->accept(*this);
+        s4o.print(";;");
+        print_retain();
+        s4o.print(";\n");
+        
+        // Now generate entries for FB fields
+        // We need to manually generate field entries with the correct array subscript path
+        declare_fb_array_element_fields(var_name, element_type, indices);
+      } else {
+        // For elementary type arrays, generate a single entry
+        print_var_number();
+        s4o.print(";VAR;");
+        print_symbol_list();
+        var_name->accept(*this);
+        s4o.print(".value.table[");
+        for (size_t i = 0; i < indices.size(); i++) {
+          if (i > 0) s4o.print("][");
+          char idx_str[32];
+          sprintf(idx_str, "%d", indices[i] - 1); // Convert to 0-based index
+          s4o.print(idx_str);
+        }
+        s4o.print("];");
+        print_symbol_list();
+        var_name->accept(*this);
+        s4o.print(".value.table[");
+        for (size_t i = 0; i < indices.size(); i++) {
+          if (i > 0) s4o.print("][");
+          char idx_str[32];
+          sprintf(idx_str, "%d", indices[i] - 1);
+          s4o.print(idx_str);
+        }
+        s4o.print("];");
+        
+        // Print base type and type name
+        element_type->accept(*this);
+        s4o.print(";");
+        array_spec->non_generic_type_name->accept(*this);
+        s4o.print(";");
+        print_retain();
+        s4o.print(";\n");
+      }
+    }
+    
+    /* Main function to declare array elements */
+    void declare_array_elements(symbol_c *symbol) {
+      // Get the array specification
+      symbol_c *array_spec = search_base_type_c::get_basetype_decl(this->current_var_type_symbol);
+      if (array_spec == NULL) ERROR;
+      
+      array_specification_c *array = dynamic_cast<array_specification_c *>(array_spec);
+      if (array == NULL) ERROR;
+      
+      // Start recursive generation
+      std::vector<int> indices;
+      declare_array_elements_recursive(symbol, array_spec, indices, 0);
+    }
+    
     void declare_variable(symbol_c *symbol) {
-      // Arrays and structures are not supported in debugging
+      // Structures are not supported in debugging
       switch (search_type_symbol->current_var_type_category) {
-          case search_type_symbol_c::array_vtc:
           case search_type_symbol_c::structure_vtc:
+          return;
+          case search_type_symbol_c::array_vtc:
+          // Arrays need special handling - generate entries for each element
+          declare_array_elements(symbol);
           return;
           default:
            break;

--- a/stage4/generate_c/generate_var_list.cc
+++ b/stage4/generate_c/generate_var_list.cc
@@ -214,10 +214,10 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
     class array_element_symbol_c : public symbol_c {
       public:
         symbol_c *array_var;
-        std::vector<int> indices;
+        std::vector<int64_t> indices;
         stage4out_c *s4o_ptr;
         
-        array_element_symbol_c(symbol_c *var, const std::vector<int> &idx, stage4out_c *s4o) 
+        array_element_symbol_c(symbol_c *var, const std::vector<int64_t> &idx, stage4out_c *s4o) 
           : array_var(var), indices(idx), s4o_ptr(s4o) {}
         
         virtual void *accept(visitor_c &visitor) {
@@ -226,9 +226,8 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
           s4o_ptr->print(".value.table[");
           for (size_t i = 0; i < indices.size(); i++) {
             if (i > 0) s4o_ptr->print("][");
-            char idx_str[32];
-            sprintf(idx_str, "%d", indices[i] - 1); // Convert to 0-based index
-            s4o_ptr->print(idx_str);
+            // Indices are already zero-based, print directly
+            s4o_ptr->print_long_long_integer(indices[i], false);
           }
           s4o_ptr->print("]");
           return NULL;
@@ -322,7 +321,7 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
     
     /* Helper function to recursively generate array element entries */
     void declare_array_elements_recursive(symbol_c *var_name, symbol_c *array_spec, 
-                                          std::vector<int> &indices, int dimension) {
+                                          std::vector<int64_t> &indices, int dimension) {
       array_specification_c *array = dynamic_cast<array_specification_c *>(array_spec);
       if (array == NULL) ERROR;
       
@@ -356,7 +355,8 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
       
       // Iterate through this dimension
       for (int64_t i = lower_bound; i <= upper_bound; i++) {
-        indices.push_back((int)i);
+        // Push zero-based index (i - lower_bound) instead of the actual bound value
+        indices.push_back(i - lower_bound);
         
         if (dimension == subrange_list->n - 1) {
           // Last dimension - generate the entry
@@ -372,7 +372,7 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
     
     /* Helper function to generate FB field entries for an array element */
     void declare_fb_array_element_fields(symbol_c *var_name, symbol_c *fb_type, 
-                                         std::vector<int> &indices) {
+                                         const std::vector<int64_t> &indices) {
       // Get the FB type declaration
       function_block_declaration_c *fb_decl = dynamic_cast<function_block_declaration_c *>(fb_type);
       if (fb_decl == NULL) {
@@ -381,7 +381,22 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
           search_base_type_c::get_basetype_decl(fb_type));
       }
       
-      if (fb_decl == NULL) return; // Not a user-defined FB, might be standard FB
+      if (fb_decl == NULL) {
+        // Not a user-defined FB, might be standard library FB
+        // For standard FBs, push the array element and call accept on the type
+        array_element_symbol_c *array_elem = new array_element_symbol_c(var_name, indices, &s4o);
+        SYMBOL *current_name = new SYMBOL;
+        current_name->symbol = array_elem;
+        current_symbol_list.push_back(*current_name);
+        
+        // Visit the FB type to generate field entries
+        fb_type->accept(*this);
+        
+        current_symbol_list.pop_back();
+        delete current_name;
+        delete array_elem;
+        return;
+      }
       
       // Visit the FB declaration to generate field entries
       // We need to temporarily add the array element to the symbol list
@@ -400,7 +415,7 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
     
     /* Helper function to generate a single array element entry */
     void declare_array_element_entry(symbol_c *var_name, array_specification_c *array_spec,
-                                     std::vector<int> &indices) {
+                                     const std::vector<int64_t> &indices) {
       // Get the element type
       symbol_c *element_type = search_base_type_c::get_basetype_decl(array_spec->non_generic_type_name);
       if (element_type == NULL) ERROR;
@@ -418,9 +433,8 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
         s4o.print(".value.table[");
         for (size_t i = 0; i < indices.size(); i++) {
           if (i > 0) s4o.print("][");
-          char idx_str[32];
-          sprintf(idx_str, "%d", indices[i] - 1); // Convert to 0-based index
-          s4o.print(idx_str);
+          // Indices are already zero-based, print directly
+          s4o.print_long_long_integer(indices[i], false);
         }
         s4o.print("];");
         print_symbol_list();
@@ -428,9 +442,7 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
         s4o.print(".value.table[");
         for (size_t i = 0; i < indices.size(); i++) {
           if (i > 0) s4o.print("][");
-          char idx_str[32];
-          sprintf(idx_str, "%d", indices[i] - 1);
-          s4o.print(idx_str);
+          s4o.print_long_long_integer(indices[i], false);
         }
         s4o.print("];");
         array_spec->non_generic_type_name->accept(*this);
@@ -450,9 +462,8 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
         s4o.print(".value.table[");
         for (size_t i = 0; i < indices.size(); i++) {
           if (i > 0) s4o.print("][");
-          char idx_str[32];
-          sprintf(idx_str, "%d", indices[i] - 1); // Convert to 0-based index
-          s4o.print(idx_str);
+          // Indices are already zero-based, print directly
+          s4o.print_long_long_integer(indices[i], false);
         }
         s4o.print("];");
         print_symbol_list();
@@ -460,9 +471,7 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
         s4o.print(".value.table[");
         for (size_t i = 0; i < indices.size(); i++) {
           if (i > 0) s4o.print("][");
-          char idx_str[32];
-          sprintf(idx_str, "%d", indices[i] - 1);
-          s4o.print(idx_str);
+          s4o.print_long_long_integer(indices[i], false);
         }
         s4o.print("];");
         
@@ -486,7 +495,7 @@ class generate_var_list_c: protected generate_c_base_and_typeid_c {
       if (array == NULL) ERROR;
       
       // Start recursive generation
-      std::vector<int> indices;
+      std::vector<int64_t> indices;
       declare_array_elements_recursive(symbol, array_spec, indices, 0);
     }
     


### PR DESCRIPTION
This pull request introduces significant improvements and fixes for handling array elements and function block (FB) instances, especially in the context of code generation for forced variables and type inference. The changes ensure correct macro expansion for both elementary and FB array elements, improve datatype propagation for symbolic variables, and refine the grammar and type search logic to support more complex variable expressions.

The most important changes are:

### Code Generation for Array Elements and Function Blocks

* Enhanced the `print_getter` and `print_setter` logic in `generate_c_st.cc` to correctly generate code for accessing and assigning array elements, distinguishing between elementary types and FBs. This ensures forced variable macros operate on the correct element, not the entire array, and handles cases like `FB_ARR[1].Q` and `INT_ARR[1]` properly. Helper methods for type checking and prefix handling were added to support this. [[1]](diffhunk://#diff-41d857f7f91b7afc3046d30582d65e1d12f75816f16b869c3362219085226f07R116-R250) [[2]](diffhunk://#diff-41d857f7f91b7afc3046d30582d65e1d12f75816f16b869c3362219085226f07R300-R384) [[3]](diffhunk://#diff-41d857f7f91b7afc3046d30582d65e1d12f75816f16b869c3362219085226f07L209-R424)
* Modified the code generation for `structured_variable_c` and `array_variable_c` to print field selectors and array suffixes in the correct order, preventing code generation errors like `MY_ARRAY.PT.table[0]` and ensuring correct access patterns. [[1]](diffhunk://#diff-41d857f7f91b7afc3046d30582d65e1d12f75816f16b869c3362219085226f07L338-R560) [[2]](diffhunk://#diff-41d857f7f91b7afc3046d30582d65e1d12f75816f16b869c3362219085226f07R575-R579) [[3]](diffhunk://#diff-41d857f7f91b7afc3046d30582d65e1d12f75816f16b869c3362219085226f07L414-R645)

### Type Inference and Datatype Propagation

* Improved datatype inference for `symbolic_variable_c` in `narrow_candidate_datatypes.cc` by automatically assigning the datatype when only one candidate exists, aligning with the behavior for literals and improving robustness for complex expressions.
* Updated the visitor logic for `fb_invocation_c` to ensure that sub-expressions in FB names (such as array accesses) are correctly typed and visited, both in candidate collection and narrowing phases. [[1]](diffhunk://#diff-d22459d8cb2c97a5d16a4959357c733b15a8c6dfda1092b4a93b66a43c4d78bdL2287-R2295) [[2]](diffhunk://#diff-354e9f56435d05a515a04a86b3b5f3c6f12aef6c4c9ca3bd3c543c4988245853R1703-R1707)

### Grammar and Type Lookup Adjustments

* Extended the grammar in `iec_bison.yy` to allow `symbolic_variable` (not just previously declared FB names) in FB invocations, enabling support for array and complex variable forms in FB calls. [[1]](diffhunk://#diff-830108a6419adbcb79eb0100b1f4eb7efa4e31748d386b90f70c967fa39a7533L7958-R7975) [[2]](diffhunk://#diff-830108a6419adbcb79eb0100b1f4eb7efa4e31748d386b90f70c967fa39a7533L2582-R2582)
* Adjusted the type lookup logic in `search_base_type.cc` to return `NULL` when a type is not found, allowing callers to handle standard library FBs and improving error handling.

### Miscellaneous Improvements

* Added a macro for declaring array type wrappers in `iec_types_all.h`, supporting the new array element handling logic.
* Included `<vector>` in `generate_c.hh` to support new data structures used in code generation.
* Improved fallback logic in `analyse_variable_c` to ensure FB instances are correctly looked up when accessed directly, especially for `VAR_IN_OUT` parameters.

These changes collectively improve the correctness and flexibility of code generation and type handling, especially for complex variable forms involving arrays and function blocks.